### PR TITLE
[B] Remove unintentional utility classes import

### DIFF
--- a/customComponents/src/components/Logo/styles.scss
+++ b/customComponents/src/components/Logo/styles.scss
@@ -1,5 +1,6 @@
 @import "src/theme/styles/_variables.scss";
-@import "src/theme/styles/base/structure/_index.scss";
+@import "src/theme/styles/base/structure/_mixins.scss";
+
 $logoPadding: 46px;
 
 .custom-logo {

--- a/customComponents/src/components/PreFooter/styles.scss
+++ b/customComponents/src/components/PreFooter/styles.scss
@@ -1,5 +1,6 @@
 @import "src/theme/styles/_variables.scss";
-@import "src/theme/styles/base/structure/_index.scss";
+@import "src/theme/styles/base/structure/_mixins.scss";
+
 $accentPrimary: #00AEF0;
 
 .custom-prefooter {


### PR DESCRIPTION
Resolves https://github.com/ManifoldScholar/manifold/issues/2831. Depends on the changes from https://github.com/ManifoldScholar/manifold/pull/2837.

Utility classes were accidentally being imported along with mixins and interfering with the stylesheet.